### PR TITLE
tag機能追加

### DIFF
--- a/app/Article.php
+++ b/app/Article.php
@@ -50,4 +50,12 @@ class Article extends Model
     // 記事モデルからlikesテーブル経由で紐付いているユーザーモデルが、コレクション(配列を拡張したもの)で返ります
     return $this->likes->count();
   }
+
+  // BelongsToMany: 記事モデルとタグモデルの関係は多対多となります
+  // 第二引数には中間テーブルのテーブル名を渡します
+  // 中間テーブルの名前がarticle_tagといった2つのモデル名の単数形をアルファベット順に結合した名前ですので、第二引数は省略可能
+  public function tags(): BelongsToMany
+  {
+    return $this->belongsToMany('App\Tag')->withTimestamps();
+  }
 }

--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Article;
+use App\Tag;
 use App\Http\Requests\ArticleRequest;
 use Illuminate\Http\Request;
 
@@ -41,6 +42,17 @@ class ArticleController extends Controller
     // ログイン済みユーザーidをArticleモデルのインスタンスのuser_idプロパティに代入
     $article->user_id = $request->user()->id;
     $article->save();
+
+    // eachメソッドに渡すコールバックは、クロージャ(無名関数)としています
+    // クロージャの第一引数にはコレクションの値が、第二引数にはコレクションのキーが入ります
+    // 第二引数は今回のクロージャの中の処理で特に使わないので、省略しています
+    // use ($article)とあるのは、クロージャの中の処理で変数$articleを使うためです
+    $request->tags->each(function ($tagName) use ($article) {
+      // 引数として渡した「カラム名と値のペア」を持つレコードがテーブルに存在するかどうかを探し、もし存在すればそのモデルを返します
+      $tag = Tag::firstOrCreate(['name' => $tagName]);
+      $article->tags()->attach($tag);
+    });
+
     return redirect()->route('articles.index');
   }
 

--- a/app/Http/Requests/ArticleRequest.php
+++ b/app/Http/Requests/ArticleRequest.php
@@ -16,9 +16,12 @@ class ArticleRequest extends FormRequest
    */
   public function authorize()
   {
+    // jsonを指定し、JSON形式かどうかのバリデーションを行います
+    // 半角スペースが無いことをチェックする正規表現です
     return [
       'title' => 'タイトル',
       'body' => '本文',
+      'tags' => 'タグ',
     ];
   }
 
@@ -32,6 +35,22 @@ class ArticleRequest extends FormRequest
       return [
         'title' => 'required|max:50',
         'body' => 'required|max:500',
+        'tags' => 'json|regex:/^(?!.*\s).+$/u',
       ];
+  }
+
+  // フォームリクエストのバリデーションが成功した後に自動的に呼ばれるメソッド
+  public function passedValidation()
+  {
+    // JSON形式の文字列であるタグ情報を連想配列に変換
+    // さらにそれをコレクションに変換
+      $this->tags = collect(json_decode($this->tags))
+          // 最初の5個だけが残ります
+          ->slice(0, 5)
+          // コレクションの各要素に対して順に処理を行い、新しいコレクションを作成します
+          // タグ情報のtextだけを返す
+          ->map(function ($requestTag) {
+              return $requestTag->text;
+          });
   }
 }

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/database/migrations/2020_03_26_000726_create_tags_table.php
+++ b/database/migrations/2020_03_26_000726_create_tags_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateTagsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            // tagsテーブルの中でnameカラムの値が同じレコードが重複して存在することができなくなります
+            $table->string('name')->unique();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tags');
+    }
+}

--- a/database/migrations/2020_03_26_001012_create_article_tag_table.php
+++ b/database/migrations/2020_03_26_001012_create_article_tag_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateArticleTagTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('article_tag', function (Blueprint $table) {
+            // onDeleteメソッドで'cascade'
+            // articlesテーブルやtagsテーブルからレコードが削除された時に、
+            // それらに紐づくarticle_tagテーブルのレコードが同時に削除される
+            $table->bigIncrements('id');
+            $table->bigInteger('article_id');
+            $table->foreign('article_id')
+                ->references('id')
+                ->on('articles')
+                ->onDelete('cascade');
+            $table->bigInteger('tag_id');
+            $table->foreign('tag_id')
+                ->references('id')
+                ->on('tags')
+                ->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('article_tag');
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -951,6 +951,15 @@
                 "to-fast-properties": "^2.0.0"
             }
         },
+        "@johmun/vue-tags-input": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@johmun/vue-tags-input/-/vue-tags-input-2.1.0.tgz",
+            "integrity": "sha512-Fdwfss/TqCqMJbGAkmlzKbcG/ia1MstYjhqPBj+zG7h/166tIcE1TIftUxhT9LZ+RWjRSG0EFA1UyaHQSr3k3Q==",
+            "dev": true,
+            "requires": {
+                "vue": "^2.6.10"
+            }
+        },
         "@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
+        "@johmun/vue-tags-input": "^2.1.0",
         "axios": "^0.19",
         "cross-env": "^5.1",
         "laravel-mix": "^4.0.7",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,10 +1,12 @@
 import './bootstrap'
 import Vue from 'vue'
 import ArticleLike from './components/ArticleLike'
+import ArticleTagsInput from './components/ArticleTagsInput'
 
 const app = new Vue({
   el: '#app',
   components: {
     ArticleLike,
+    ArticleTagsInput,
   }
 })

--- a/resources/js/components/ArticleTagsInput.vue
+++ b/resources/js/components/ArticleTagsInput.vue
@@ -1,0 +1,72 @@
+<template>
+  <div>
+    <!-- 
+      bladeからformタグだとPOST送信できない
+      コンポーネント中の'hidden'でタグ情報を送る　-->
+    <input
+      type="hidden"
+      name="tags"
+      :value="tagsJson"
+    >
+    <vue-tags-input
+      v-model="tag"
+      :tags="tags"
+      placeholder="タグを5個まで入力できます"
+      :autocomplete-items="filteredItems"
+      @tags-changed="newTags => tags = newTags"
+    />
+  </div>
+</template>
+
+<script>
+import VueTagsInput from '@johmun/vue-tags-input';
+
+export default {
+  components: {
+    VueTagsInput,
+  },
+  data() {
+    return {
+      tag: '',
+      tags: [],
+      autocompleteItems: [{
+        text: 'Spain',
+      }, {
+        text: 'France',
+      }, {
+        text: 'USA',
+      }, {
+        text: 'Germany',
+      }, {
+        text: 'China',
+      }],
+    };
+  },
+  computed: {
+    filteredItems() {
+      return this.autocompleteItems.filter(i => {
+        return i.text.toLowerCase().indexOf(this.tag.toLowerCase()) !== -1;
+      });
+    },
+    tagsJson() {
+      // データtagsをJSON形式の文字列に変換したものを返しています
+      return JSON.stringify(this.tags)
+    },
+  },
+};
+</script>
+<style lang="css" scoped>
+  .vue-tags-input {
+    max-width: inherit;
+  }
+</style>
+<style lang="css">
+  .vue-tags-input .ti-tag {
+    background: transparent;
+    border: 1px solid #747373;
+    color: #747373;
+    margin-right: 4px;
+    border-radius: 0px;
+    font-size: 13px;
+  }
+</style>

--- a/resources/views/articles/card.blade.php
+++ b/resources/views/articles/card.blade.php
@@ -79,5 +79,21 @@
         </article-like>
       </div>
     </div>
+    @foreach($article->tags as $tag)
+      @if($loop->first)
+        <!-- 繰り返し処理の最初の1回目 -->
+        <div class="card-body pt-0 pb-4 pl-3">
+          <div class="card-text line-height">
+      @endif
+            <!-- 画面でタグを押すと、そのタグの付いた記事だけを一覧表示する -->
+            <a href="" class="border p-1 mr-1 mt-1 text-muted">
+              {{ $tag->name }}
+            </a>
+      @if($loop->last)
+          <!-- 繰り返し処理の最後だけ -->
+          </div>
+        </div>
+      @endif
+    @endforeach
   </div>
 </div>

--- a/resources/views/articles/form.blade.php
+++ b/resources/views/articles/form.blade.php
@@ -8,6 +8,11 @@
   <input type="text" name="title" class="form-control" required value="{{ $article->title ?? old('title') }}">
 </div>
 <div class="form-group">
+  <article-tags-input
+  >
+  </article-tags-input>
+</div>
+<div class="form-group">
   <label></label>
   <!-- NULL合体演算子 -->
   <textarea name="body" required class="form-control" rows="16" placeholder="本文">{{ $article->body ?? old('body') }}</textarea>


### PR DESCRIPTION
目的
・5つまでtagを付与でき記事内容を分類する
実装
・タグインプットフォームはvueコンポーネントに分ける
・入力されたタグはbladeからPOST送信される
・空白を含むタグはバリデーションで弾かれる
課題
・記事更新の際に前回のタグを持っていない