### PR TITLE
tag更新機能修正

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -58,7 +58,14 @@ class ArticleController extends Controller
 
   public function edit(Article $article)
   {
-    return view('articles.edit', ['article' => $article]);
+    $tagNames = $article->tags->map(function ($tag) {
+      return ['text' => $tag->name];
+    });
+
+    return view('articles.edit', [
+      'article' => $article,
+      'tagNames' => $tagNames,
+    ]);
   }
 
   public function update(ArticleRequest $request, Article $article)

--- a/resources/js/components/ArticleTagsInput.vue
+++ b/resources/js/components/ArticleTagsInput.vue
@@ -28,7 +28,7 @@ export default {
   data() {
     return {
       tag: '',
-      tags: [],
+      tags: this.initialTags,
       autocompleteItems: [{
         text: 'Spain',
       }, {
@@ -41,6 +41,12 @@ export default {
         text: 'China',
       }],
     };
+  },
+  props: {
+    initialTags: {
+      type: Array,
+      default: [],
+    },
   },
   computed: {
     filteredItems() {

--- a/resources/views/articles/form.blade.php
+++ b/resources/views/articles/form.blade.php
@@ -9,6 +9,7 @@
 </div>
 <div class="form-group">
   <article-tags-input
+    :initial-tags='@json($tagNames ?? [])'
   >
   </article-tags-input>
 </div>


### PR DESCRIPTION
目的
・記事更新の際に付与されていたtagを表示
実装
・bladeから$initialTagsとしてpropsで受け取り、tagの初期値として表示