### PR TITLE
tag削除機能追加

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -71,6 +71,15 @@ class ArticleController extends Controller
   public function update(ArticleRequest $request, Article $article)
   {
     $article->fill($request->all())->save();
+
+    // detachメソッドを引数無しで使うと、そのリレーションを紐付ける中間テーブルのレコードが全削除されます
+    // 一旦全削除して、新しくタグを登録し直す
+    $article->tags()->detach();
+      $request->tags->each(function ($tagName) use ($article) {
+          $tag = Tag::firstOrCreate(['name' => $tagName]);
+          $article->tags()->attach($tag);
+      });
+
     return redirect()->route('articles.index');
   }
 


### PR DESCRIPTION
目的
・tag削除機能削除
実装
・detachメソッドを最初に実行することでtag更新の際には一旦全て削除
・その上で更新する際には新しく登録する処理