### PR TITLE
tag自動保管機能追加

### DIFF
--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -28,7 +28,15 @@ class ArticleController extends Controller
 
   public function create()
   {
-    return view('articles.create');
+    // タグテーブルから全てのタグ情報を取得し、Bladeに変数$allTagNamesとして渡しています
+    // タグテーブルに登録済みのタグ数が膨大になってきた場合考慮必要
+    $allTagNames = Tag::all()->map(function ($tag) {
+      return ['text' => $tag->name];
+    });
+
+    return view('articles.create', [
+        'allTagNames' => $allTagNames,
+    ]);
   }
 
   // 引数$requestはArticleRequestクラスのインスタンスである、ということを宣言
@@ -62,9 +70,16 @@ class ArticleController extends Controller
       return ['text' => $tag->name];
     });
 
+    // タグテーブルから全てのタグ情報を取得し、Bladeに変数$allTagNamesとして渡しています
+    // タグテーブルに登録済みのタグ数が膨大になってきた場合に考慮必要
+    $allTagNames = Tag::all()->map(function ($tag) {
+      return ['text' => $tag->name];
+    });
+
     return view('articles.edit', [
       'article' => $article,
       'tagNames' => $tagNames,
+      'allTagNames' => $allTagNames,
     ]);
   }
 

--- a/resources/js/components/ArticleTagsInput.vue
+++ b/resources/js/components/ArticleTagsInput.vue
@@ -29,17 +29,6 @@ export default {
     return {
       tag: '',
       tags: this.initialTags,
-      autocompleteItems: [{
-        text: 'Spain',
-      }, {
-        text: 'France',
-      }, {
-        text: 'USA',
-      }, {
-        text: 'Germany',
-      }, {
-        text: 'China',
-      }],
     };
   },
   props: {
@@ -47,6 +36,10 @@ export default {
       type: Array,
       default: [],
     },
+    autocompleteItems: {
+      type: Array,
+      default: [],
+    }
   },
   computed: {
     filteredItems() {

--- a/resources/views/articles/form.blade.php
+++ b/resources/views/articles/form.blade.php
@@ -10,6 +10,7 @@
 <div class="form-group">
   <article-tags-input
     :initial-tags='@json($tagNames ?? [])'
+    :autocomplete-items='@json($allTagNames ?? [])'
   >
   </article-tags-input>
 </div>


### PR DESCRIPTION
目的
・tag入力候補を表示
実装
・Tagモデルから登録ずみのtagを候補として表示させる
課題
・モデルから全てのタグを持ってきているので今後数が増えた場合も考える必要あり
・どういう基準で候補として表示させるのか要検討