### PR TITLE
スペースキーでもtagを追加できる仕様変更

### DIFF
--- a/resources/js/components/ArticleTagsInput.vue
+++ b/resources/js/components/ArticleTagsInput.vue
@@ -13,6 +13,7 @@
       :tags="tags"
       placeholder="タグを5個まで入力できます"
       :autocomplete-items="filteredItems"
+      :add-on-key="[13, 32]"
       @tags-changed="newTags => tags = newTags"
     />
   </div>


### PR DESCRIPTION
目的
・スペースキーでもtagを追加できる仕様変更
実装
・Enterキーだけでtagを追加できていたのでSpaceキーでも追加可能に変更
・プロパティadd-on-keyにキーの種類を配列で渡すと、それらのキーがタグ確定キーとなります