### PR TITLE
ユーザー投稿・いいねした記事表示

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -10,9 +10,25 @@ class UserController extends Controller
     {
         // $nameと一致する名前を持つユーザーモデルをコレクションで取得
         $user = User::where('name', $name)->first();
+        // ユーザーモデルに追加したリレーションのarticlesを使って、ユーザーの投稿した記事モデルをコレクションで取得
+        $articles = $user->articles->sortByDesc('created_at');
  
         return view('users.show', [
             'user' => $user,
+            'articles' => $articles,
+        ]);
+    }
+
+    public function likes(string $name)
+    {
+        $user = User::where('name', $name)->first();
+        
+        // いいねした記事モデルのコレクションを代入
+        $articles = $user->likes->sortByDesc('created_at');
+ 
+        return view('users.likes', [
+            'user' => $user,
+            'articles' => $articles,
         ]);
     }
 

--- a/app/User.php
+++ b/app/User.php
@@ -6,6 +6,7 @@ use App\Mail\BareMail;
 use App\Notifications\PasswordResetNotification;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -47,6 +48,12 @@ class User extends Authenticatable
         $this->notify(new PasswordResetNotification($token, new BareMail()));
     }
 
+    // ユーザーと、そのユーザーの投稿した記事は1対多の関係ですが、そのような関係性の場合には、hasManyメソッドを使います
+    public function articles(): HasMany
+    {
+        return $this->hasMany('App\Article');
+    }
+
     // ユーザーモデルから「フォロワーであるユーザー」のモデルにアクセス可能にするメソッド
     // フォローにおけるユーザーモデルとユーザーモデルの関係は多対多となります
     // 第一引数には関係するモデルのモデル名
@@ -65,6 +72,12 @@ class User extends Authenticatable
     public function followings(): BelongsToMany
     {
         return $this->belongsToMany('App\User', 'follows', 'follower_id', 'followee_id')->withTimestamps();
+    }
+
+    // 「いいね」におけるユーザーモデルと記事モデルの関係は多対多となります
+    public function likes(): BelongsToMany
+    {
+        return $this->belongsToMany('App\Article', 'likes')->withTimestamps();
     }
 
     // あるユーザーをフォロー中かどうか判定するメソッド

--- a/resources/views/users/likes.blade.php
+++ b/resources/views/users/likes.blade.php
@@ -1,13 +1,13 @@
 @extends('app')
 
-@section('title', $user->name . 'の記事')
+@section('title', $user->name . 'のいいねした記事')
 
 @section('content')
   @include('nav')
   <div class="container">
     @include('users.user')
     <!-- 第二引数に変数名とその値を連想配列形式で渡すことができます -->
-    @include('users.tabs', ['hasArticles' => true, 'hasLikes' => false])
+    @include('users.tabs', ['hasArticles' => false, 'hasLikes' => true])
     @foreach($articles as $article)
       @include('articles.card')
     @endforeach

--- a/resources/views/users/tabs.blade.php
+++ b/resources/views/users/tabs.blade.php
@@ -1,0 +1,16 @@
+<ul class="nav nav-tabs nav-justified mt-3">
+  <li class="nav-item">
+    <!-- 変数$hasArticlesと$hasLikesを使って、
+         その値によってclass属性に'active'を付加するかどうかを三項演算子で制御します -->
+    <a class="nav-link text-muted {{ $hasArticles ? 'active' : '' }}"
+       href="{{ route('users.show', ['name' => $user->name]) }}">
+      記事
+    </a>
+  </li>
+  <li class="nav-item">
+    <a class="nav-link text-muted {{ $hasLikes ? 'active' : '' }}"
+       href="{{ route('users.likes', ['name' => $user->name]) }}">
+      いいね
+    </a>
+  </li>
+</ul>

--- a/resources/views/users/user.blade.php
+++ b/resources/views/users/user.blade.php
@@ -1,0 +1,38 @@
+<div class="card mt-3">
+  <div class="card-body">
+    <div class="d-flex flex-row">
+      <a href="{{ route('users.show', ['name' => $user->name]) }}" class="text-dark">
+        <i class="fas fa-user-circle fa-3x"></i>
+      </a>
+      <!-- ログイン中のユーザーのidと、ユーザーページに表示されるユーザーのidを比較し、不一致の場合のみフォローボタンを表示する -->
+      <!-- Authファサードのcheckメソッドを使うと、ログイン中かどうかを論理値で返します -->
+      <!-- プロパティendpointを新たに定義し、Laravelのroute関数で取得したURLを渡しています -->
+      @if( Auth::id() !== $user->id )
+        <follow-button
+          class="ml-auto"
+          :initial-is-followed-by='@json($user->isFollowedBy(Auth::user()))'
+          :authorized='@json(Auth::check())'
+          endpoint="{{ route('users.follow', ['name' => $user->name]) }}"
+        >
+        </follow-button>
+      @endif
+    </div>
+    <h2 class="h5 card-title m-0">
+      <a href="{{ route('users.show', ['name' => $user->name]) }}" class="text-dark">
+        {{ $user->name }}
+      </a>
+    </h2>
+  </div>
+  <div class="card-body">
+    <div class="card-text">
+      <a href="" class="text-muted">
+      <!-- getCountFollowingssAttributeアクセサを利用する記述 -->
+        <b>{{ $user->count_followings }}</b> フォロー中
+      </a>
+      <a href="" class="text-muted">
+      <!-- getCountFollowersAttributeアクセサを利用する記述 -->
+        <b>{{ $user->count_followers }}</b> フォロワー
+      </a>
+    </div>
+  </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,8 @@ Route::get('/tags/{name}', 'TagController@show')->name('tags.show');
 // prefixメソッドとnameメソッドを使った上でgroupメソッドを使うことで、URIとルーティングの名前を簡潔に記述できるようにしています
 Route::prefix('users')->name('users.')->group(function () {
     Route::get('/{name}', 'UserController@show')->name('show');
+    // いいねタブが押された場合のユーザーページ表示のルーティング
+    Route::get('/{name}/likes', 'UserController@likes')->name('likes');
 
     Route::middleware('auth')->group(function () {
         Route::put('/{name}/follow', 'UserController@follow')->name('follow');


### PR DESCRIPTION
目的
・ユーザーページにて投稿・いいねした記事表示
実装
・「いいねした記事一覧」表示用のルーティングを新規追加
・記事一覧といいねした記事一覧の共通部分を別bladeで読み込むことで可読性を高める